### PR TITLE
[WIP] Adding a tokio example

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rust/tokio"]
+	path = rust/tokio
+	url = https://github.com/TilCreator/tokio.git

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,7 @@ esp-idf-sys = {git = "https://github.com/ivmarkov/esp-idf-sys.git"}
 #esp-idf-sys = {path = "../../esp-idf-sys"}
 rocket = "0.4.6"
 indexmap = "=1.2" # Rocket 0.4.6 fails to compile with later versions...
-tokio = { features = [ "rt", "rt-multi-thread", "time", "macros" ], path = "../../tokio/tokio" }
+tokio = { features = [ "rt", "rt-multi-thread", "time", "macros" ], path = "tokio/tokio" }
 
 [patch.crates-io]
 time = { git = 'https://github.com/ivmarkov/time.git', branch = 'master' }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,6 +10,7 @@ esp-idf-sys = {git = "https://github.com/ivmarkov/esp-idf-sys.git"}
 #esp-idf-sys = {path = "../../esp-idf-sys"}
 rocket = "0.4.6"
 indexmap = "=1.2" # Rocket 0.4.6 fails to compile with later versions...
+tokio = { features = [ "rt", "rt-multi-thread", "time", "macros" ], path = "../../tokio/tokio" }
 
 [patch.crates-io]
 time = { git = 'https://github.com/ivmarkov/time.git', branch = 'master' }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,11 +1,16 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 #[macro_use] extern crate rocket;
 
-use std::time::*;
 use std::thread;
 
 use std::ffi::{CString};
 use esp_idf_sys::*;
+
+use tokio::{
+    join,
+    runtime::Runtime,
+    time::{sleep, Duration},
+};
 
 mod wip;
 
@@ -14,6 +19,8 @@ pub extern "C" fn main() {
     simple_playground();
 
     threads_playground();
+
+    tokio_playground();
 
     // Enough playing. Start WiFi and ignite the Rocket framework
 
@@ -66,6 +73,42 @@ fn threads_playground() {
     thread::sleep(Duration::new(2, 0));
 
     println!("Joins were successful.");
+}
+
+fn tokio_playground() {
+    Runtime::new().unwrap().block_on(async {
+        join!(
+            async { // Jessie
+                println!("Jessie: Prepare for trouble");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("Jessie: To protect the world from devastation!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("Jessie: To denounce the evils of truth and love!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("Jessie: Jessie!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("Jessie: Team Rocket blasts off at the speed of light!");
+            },
+            async { // James
+                sleep(Duration::from_secs_f64(0.5)).await;
+                println!("James: And make it double");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("James: To unite all peoples within our nation!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("James: To extend our reach to the stars above!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("James: James!");
+                sleep(Duration::from_secs_f64(1.0)).await;
+                println!("James: Surrender now, or prepare to fight!");
+            },
+            async { // Meowth
+                sleep(Duration::from_secs_f64(5.5)).await;
+                println!("Meowth: Meowth!");
+                sleep(Duration::from_secs_f64(0.5)).await;
+                println!("Meowth: That's right!");
+            },
+        )
+    });
 }
 
 // NOTE:


### PR DESCRIPTION
This example uses my Tokio fork, because Tokio doesn't know that xtensa doesn't support native atomic u64.
This example also currently still fails with:
```
Hello, world from Rust!
More complex print ["foo", "bar"]
Rust main thread: Thread { id: ThreadId(1), name: None }
This is thread number 1, Thread { id: ThreadId(3), name: None }
This is thread number 0, Thread { id: ThreadId(2), name: None }
This is thread number 2, Thread { id: ThreadId(4), name: None }
This is thread number 3, Thread { id: ThreadId(5), name: None }
This is thread number 4, Thread { id: ThreadId(6), name: None }
About to join the threads. If ESP-IDF was patched successfully, joining will NOT crash
Joins were successful.
Jessie: Prepare for trouble
thread 'tokio-runtime-worker' panicked at 'assertion failed: r == libc::ETIMEDOUT || r == 0', /root/projects/esp32-ivmarkov/rust/library/std/src/sys/unix/condvar.rs:102:9
```
(`r` is `EINVAL` in ESP-IDF `components/pthread/pthread_cond_var.c:94`)

I'm currently working on this from time to time, maybe someone want's to help?
(Also I don't have a Jtag debugger, so I'm doing print "debugging" on a microcontroller...)