### PR TITLE
Use partition table from this repo with espflash

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Highlights:
 ## Flash
 
 - `cargo install espflash`
-- `espflash flash -p /dev/ttyUSB0 target/[xtensa-esp32-espidf|xtensa-esp32s2-espidf|riscv32imc-esp-espidf]/debug/rust-esp32-std-demo`
+- `espflash flash --partition-table partitions.csv -p /dev/ttyUSB0 target/[xtensa-esp32-espidf|xtensa-esp32s2-espidf|riscv32imc-esp-espidf]/debug/rust-esp32-std-demo`
 - Replace `dev/ttyUSB0` above with the USB port where you've connected the board
 
 **NOTE**: The above commands do use [`espflash`](https://crates.io/crates/espflash) and NOT [`cargo espflash`](https://crates.io/crates/cargo-espflash), even though both can be installed via Cargo. `cargo espflash` is essentially `espflash` but it has some extra superpowers, like the capability to build the project before flashing, or to generate an ESP32 .BIN file from the built .ELF image.


### PR DESCRIPTION
What about making the partition table explicit and not relying on lucky defaults from `espflash`? What about integrating this together with #117 which works like a charm for me when using `cargo espflash`.